### PR TITLE
Make this library feel easier to use

### DIFF
--- a/libass/Cargo.toml
+++ b/libass/Cargo.toml
@@ -13,3 +13,6 @@ categories =  ["api-bindings", "multimedia", "multimedia::video", "graphics"]
 libc = "0.2.54"
 libass-sys = { version = "0.1.1", path = '../libass-sys' }
 bitflags = "1.1.0"
+
+[dev-dependencies]
+png = "0.16.7"

--- a/libass/examples/test.rs
+++ b/libass/examples/test.rs
@@ -1,0 +1,69 @@
+use std::{error::Error, env, fs::File, io::BufWriter};
+
+use libass::{DefaultFontProvider, Layer, Library};
+
+fn draw_layer(layer: Layer, dst: &mut [u8]) {
+    let a = (255 - (layer.color & 0xFF)) as u8;
+    let r = (layer.color >> 24) as u8;
+    let g = (layer.color >> 16 & 0xFF) as u8;
+    let b = (layer.color >> 8 & 0xFF) as u8;
+    let pixel_base = [r, g, b, a];
+
+    for y in 0..layer.height as usize {
+        for x in 0..layer.width as usize {
+            let k = layer.bitmap[y * layer.width as usize + x] as u16;
+
+            let dst_x = x + layer.x as usize;
+            let dst_y = y + layer.y as usize;
+            let dst_p = (dst_y * 1920 + dst_x) * 4;
+
+            for i in dst_p..dst_p + 4 {
+                let off = i - dst_p;
+                let dst_orig = dst[i] as u16;
+                dst[i] = ((k * pixel_base[off] as u16 + (255 - k) * dst_orig) / 255) as u8;
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 4 {
+        eprintln!("usage: {} <image file> <subtitle file> <time>", args[0]);
+        return Ok(());
+    }
+
+    let img_file = File::create(&args[1])?;
+    let img_writer = BufWriter::new(img_file);
+    let mut encoder = png::Encoder::new(img_writer, 1920, 1080);
+    encoder.set_color(png::ColorType::RGBA);
+    encoder.set_depth(png::BitDepth::Eight);
+
+    let sub_file = &args[2];
+    let timestamp: i64 = args[3].parse()?;
+
+    let lib = Library::new()?;
+    let mut renderer = lib.new_renderer()?;
+    renderer.set_frame_size(1920, 1080);
+    renderer.set_fonts(
+        None,
+        Some("sans-serif"),
+        DefaultFontProvider::Autodetect,
+        None,
+        false,
+    );
+    
+    let track = lib.new_track_from_file(sub_file)?;
+    let frame = renderer.render_frame(track, timestamp);
+    let image = frame.0.unwrap();
+
+    let mut framebuffer = vec![0u8; 1920 * 1080 * 4];
+
+    for layer in image {
+        draw_layer(layer, &mut framebuffer);
+    }
+
+    let mut writer = encoder.write_header()?;
+    writer.write_image_data(&framebuffer)?;
+    Ok(())
+}

--- a/libass/examples/test.rs
+++ b/libass/examples/test.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         false,
     );
     
-    let track = lib.new_track_from_file(sub_file)?;
+    let track = lib.new_track_from_file(sub_file, "UTF-8")?;
     let frame = renderer.render_frame(track, timestamp);
     let image = frame.0.unwrap();
 

--- a/libass/examples/test.rs
+++ b/libass/examples/test.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, env, fs::File, io::BufWriter};
+use std::{env, error::Error, fs::File, io::BufWriter};
 
 use libass::{DefaultFontProvider, Layer, Library};
 
@@ -47,12 +47,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     renderer.set_frame_size(1920, 1080);
     renderer.set_fonts(
         None,
-        Some("sans-serif"),
+        "sans-serif",
         DefaultFontProvider::Autodetect,
         None,
         false,
     );
-    
+
     let track = lib.new_track_from_file(sub_file, "UTF-8")?;
     let frame = renderer.render_frame(track, timestamp);
     let image = frame.0.unwrap();

--- a/libass/src/lib.rs
+++ b/libass/src/lib.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 mod library;
 pub use crate::library::*;
 
@@ -12,3 +14,23 @@ pub use crate::image::*;
 
 mod style;
 pub use crate::style::*;
+
+#[derive(Debug)]
+pub struct AssError;
+impl std::fmt::Display for AssError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Libass Error")
+    }
+}
+impl Error for AssError {}
+
+pub type AssResult<T> = Result<T, AssError>;
+
+#[macro_export]
+macro_rules! err_if_null {
+    ($e:expr) => {
+        if $e.is_null() {
+            return Err(crate::AssError);
+        }
+    };
+}

--- a/libass/src/lib.rs
+++ b/libass/src/lib.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 mod library;
 pub use crate::library::*;
 
@@ -16,21 +14,21 @@ mod style;
 pub use crate::style::*;
 
 #[derive(Debug)]
-pub struct AssError;
-impl std::fmt::Display for AssError {
+pub struct Error;
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Libass Error")
     }
 }
-impl Error for AssError {}
+impl std::error::Error for Error {}
 
-pub type AssResult<T> = Result<T, AssError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[macro_export]
 macro_rules! err_if_null {
     ($e:expr) => {
         if $e.is_null() {
-            return Err(crate::AssError);
+            return Err(crate::Error);
         }
     };
 }

--- a/libass/src/library.rs
+++ b/libass/src/library.rs
@@ -1,7 +1,7 @@
-use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::ptr;
+use std::ptr::null_mut;
 use std::ptr::NonNull;
 use std::slice;
 
@@ -9,6 +9,7 @@ use libass_sys as ffi;
 
 use crate::renderer::Renderer;
 use crate::track::Track;
+use crate::{err_if_null, AssResult};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DefaultFontProvider {
@@ -29,27 +30,24 @@ pub struct Library<'a> {
 }
 
 impl<'a> Library<'a> {
-    pub fn new() -> Option<Self> {
+    pub fn new() -> AssResult<Self> {
         let lib = unsafe { ffi::ass_library_init() };
-        if lib.is_null() {
-            None
-        } else {
-            Some(Library {
-                handle: unsafe { NonNull::new_unchecked(lib) },
-                phantom: PhantomData,
-            })
-        }
+        err_if_null!(lib);
+        Ok(Library {
+            handle: unsafe { NonNull::new_unchecked(lib) },
+            phantom: PhantomData,
+        })
     }
 
-    pub fn set_fonts_dir(&mut self, fonts_dir: &CStr) {
-        unsafe { ffi::ass_set_fonts_dir(self.handle.as_ptr(), fonts_dir.as_ptr()) }
+    pub fn set_fonts_dir(&mut self, fonts_dir: &str) {
+        unsafe { ffi::ass_set_fonts_dir(self.handle.as_ptr(), fonts_dir.as_ptr() as *const i8) }
     }
 
     pub fn set_extract_fonts(&mut self, extract: bool) {
         unsafe { ffi::ass_set_extract_fonts(self.handle.as_ptr(), extract as c_int) }
     }
 
-    pub fn set_style_overrides(&mut self, list: &[&CStr]) {
+    pub fn set_style_overrides(&mut self, list: &[&str]) {
         unsafe {
             ffi::ass_set_style_overrides(
                 self.handle.as_ptr(),
@@ -62,7 +60,7 @@ impl<'a> Library<'a> {
         };
     }
 
-    pub fn add_font(&mut self, name: &CStr, data: &[u8]) {
+    pub fn add_font(&mut self, name: &str, data: &[u8]) {
         unsafe {
             ffi::ass_add_font(
                 self.handle.as_ptr(),
@@ -109,42 +107,32 @@ impl<'a> Library<'a> {
         vec
     }
 
-    pub fn new_renderer(&self) -> Option<Renderer> {
+    pub fn new_renderer(&self) -> AssResult<Renderer> {
         let renderer = unsafe { ffi::ass_renderer_init(self.handle.as_ptr() as *mut _) };
-
-        if renderer.is_null() {
-            None
-        } else {
-            unsafe { Some(Renderer::new_unchecked(renderer)) }
-        }
+        err_if_null!(renderer);
+        unsafe { Ok(Renderer::new_unchecked(renderer)) }
     }
 
-    pub fn new_track(&self) -> Option<Track> {
+    pub fn new_track(&self) -> AssResult<Track> {
         let track = unsafe { ffi::ass_new_track(self.handle.as_ptr() as *mut _) };
-        if track.is_null() {
-            None
-        } else {
-            unsafe { Some(Track::new_unchecked(track)) }
-        }
+        err_if_null!(track);
+        unsafe { Ok(Track::new_unchecked(track)) }
     }
 
-    pub fn new_track_from_file(&self, filename: &CStr, codepage: &CStr) -> Option<Track> {
+    pub fn new_track_from_file(&self, filename: &str) -> AssResult<Track> {
         let track = unsafe {
             ffi::ass_read_file(
                 self.handle.as_ptr() as *mut _,
                 filename.as_ptr() as *mut _,
-                codepage.as_ptr() as *mut _,
+                null_mut(),
             )
         };
 
-        if track.is_null() {
-            None
-        } else {
-            unsafe { Some(Track::new_unchecked(track)) }
-        }
+        err_if_null!(track);
+        unsafe { Ok(Track::new_unchecked(track)) }
     }
 
-    pub fn new_track_from_memory(&self, data: &[u8], codepage: &CStr) -> Option<Track> {
+    pub fn new_track_from_memory(&self, data: &[u8], codepage: &str) -> AssResult<Track> {
         let track = unsafe {
             ffi::ass_read_memory(
                 self.handle.as_ptr() as *mut _,
@@ -154,11 +142,8 @@ impl<'a> Library<'a> {
             )
         };
 
-        if track.is_null() {
-            None
-        } else {
-            unsafe { Some(Track::new_unchecked(track)) }
-        }
+        err_if_null!(track);
+        unsafe { Ok(Track::new_unchecked(track)) }
     }
 }
 

--- a/libass/src/library.rs
+++ b/libass/src/library.rs
@@ -9,7 +9,7 @@ use libass_sys as ffi;
 
 use crate::renderer::Renderer;
 use crate::track::Track;
-use crate::{err_if_null, AssResult};
+use crate::{err_if_null, Result};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DefaultFontProvider {
@@ -30,7 +30,7 @@ pub struct Library<'a> {
 }
 
 impl<'a> Library<'a> {
-    pub fn new() -> AssResult<Self> {
+    pub fn new() -> Result<Self> {
         let lib = unsafe { ffi::ass_library_init() };
         err_if_null!(lib);
         Ok(Library {
@@ -107,19 +107,19 @@ impl<'a> Library<'a> {
         vec
     }
 
-    pub fn new_renderer(&self) -> AssResult<Renderer> {
+    pub fn new_renderer(&self) -> Result<Renderer> {
         let renderer = unsafe { ffi::ass_renderer_init(self.handle.as_ptr() as *mut _) };
         err_if_null!(renderer);
         unsafe { Ok(Renderer::new_unchecked(renderer)) }
     }
 
-    pub fn new_track(&self) -> AssResult<Track> {
+    pub fn new_track(&self) -> Result<Track> {
         let track = unsafe { ffi::ass_new_track(self.handle.as_ptr() as *mut _) };
         err_if_null!(track);
         unsafe { Ok(Track::new_unchecked(track)) }
     }
 
-    pub fn new_track_from_file(&self, filename: &str) -> AssResult<Track> {
+    pub fn new_track_from_file(&self, filename: &str) -> Result<Track> {
         let track = unsafe {
             ffi::ass_read_file(
                 self.handle.as_ptr() as *mut _,
@@ -132,7 +132,7 @@ impl<'a> Library<'a> {
         unsafe { Ok(Track::new_unchecked(track)) }
     }
 
-    pub fn new_track_from_memory(&self, data: &[u8], codepage: &str) -> AssResult<Track> {
+    pub fn new_track_from_memory(&self, data: &[u8], codepage: &str) -> Result<Track> {
         let track = unsafe {
             ffi::ass_read_memory(
                 self.handle.as_ptr() as *mut _,

--- a/libass/src/library.rs
+++ b/libass/src/library.rs
@@ -40,7 +40,7 @@ impl<'a> Library<'a> {
 
     pub fn set_fonts_dir(&mut self, fonts_dir: &str) {
         let fonts_dir = CString::new(fonts_dir).unwrap();
-        unsafe { ffi::ass_set_fonts_dir(self.handle.as_ptr(), fonts_dir.as_ptr() as *const i8) }
+        unsafe { ffi::ass_set_fonts_dir(self.handle.as_ptr(), fonts_dir.as_ptr()) }
     }
 
     pub fn set_extract_fonts(&mut self, extract: bool) {

--- a/libass/src/renderer.rs
+++ b/libass/src/renderer.rs
@@ -1,7 +1,7 @@
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::ptr::NonNull;
-use std::ffi::CString;
 
 use crate::image::Image;
 use crate::library::DefaultFontProvider;
@@ -71,18 +71,25 @@ impl<'library> Renderer<'library> {
         }
     }
 
-    pub fn set_fonts(
+    pub fn set_fonts<'a>(
         &mut self,
-        default_font: Option<&str>,
-        default_family: Option<&str>,
+        default_font: impl Into<Option<&'a str>>,
+        default_family: impl Into<Option<&'a str>>,
         default_font_provider: DefaultFontProvider,
-        fontconfig_config_path: Option<&str>,
+        fontconfig_config_path: impl Into<Option<&'a str>>,
         update_fontconfig_cache: bool,
     ) {
+        let default_font: Option<CString> = default_font.into().map(|x| CString::new(x).unwrap());
+        let default_family: Option<CString> =
+            default_family.into().map(|x| CString::new(x).unwrap());
+        let fontconfig_config_path: Option<CString> = fontconfig_config_path
+            .into()
+            .map(|x| CString::new(x).unwrap());
+
         macro_rules! unwrap_or_null {
             ($x:expr) => {
                 match $x {
-                    Some(s) => CString::new(s).unwrap().as_ptr(),
+                    Some(ref s) => s.as_ptr(),
                     None => ::std::ptr::null(),
                 }
             };

--- a/libass/src/renderer.rs
+++ b/libass/src/renderer.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::ptr::NonNull;
+use std::ffi::CString;
 
 use crate::image::Image;
 use crate::library::DefaultFontProvider;
@@ -81,7 +82,7 @@ impl<'library> Renderer<'library> {
         macro_rules! unwrap_or_null {
             ($x:expr) => {
                 match $x {
-                    Some(s) => s.as_ptr() as *const i8,
+                    Some(s) => CString::new(s).unwrap().as_ptr(),
                     None => ::std::ptr::null(),
                 }
             };

--- a/libass/src/renderer.rs
+++ b/libass/src/renderer.rs
@@ -1,4 +1,3 @@
-use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::ptr::NonNull;
@@ -73,16 +72,16 @@ impl<'library> Renderer<'library> {
 
     pub fn set_fonts(
         &mut self,
-        default_font: Option<&CStr>,
-        default_family: Option<&CStr>,
+        default_font: Option<&str>,
+        default_family: Option<&str>,
         default_font_provider: DefaultFontProvider,
-        fontconfig_config_path: Option<&CStr>,
+        fontconfig_config_path: Option<&str>,
         update_fontconfig_cache: bool,
     ) {
         macro_rules! unwrap_or_null {
             ($x:expr) => {
                 match $x {
-                    Some(s) => s.as_ptr(),
+                    Some(s) => s.as_ptr() as *const i8,
                     None => ::std::ptr::null(),
                 }
             };


### PR DESCRIPTION
What I have changed:
* Added the official test example (it works pretty well, but I don't know if it's totally correct)
* Changed every `CStr` in arguments to `str`
* Use `Result` instead of `Option` when checking for returned null pointers (they are actually errors), so we can do `Library::new()?`
* I don't know why libass keeps complaining about my codepage argument, so I just removed it so that it defaults to UTF-8