### PR TITLE
Use &mut to allow subsequent calls to `render_frame`

### DIFF
--- a/libass/src/renderer.rs
+++ b/libass/src/renderer.rs
@@ -44,18 +44,12 @@ impl<'library> Renderer<'library> {
         }
     }
 
-    pub fn render_frame(&mut self, track: Track, now: i64) -> (Option<Image>, Change) {
+    pub fn render_frame(&mut self, track: &mut Track, now: i64) -> (Option<Image>, Change) {
         let mut change = 0;
         let change_ptr: *mut _ = &mut change;
 
-        let image = unsafe {
-            ffi::ass_render_frame(
-                self.handle.as_ptr(),
-                track.as_ptr() as *mut _,
-                now,
-                change_ptr,
-            )
-        };
+        let image =
+            unsafe { ffi::ass_render_frame(self.handle.as_ptr(), track.as_ptr(), now, change_ptr) };
 
         let change = match change {
             0 => Change::None,

--- a/libass/src/track.rs
+++ b/libass/src/track.rs
@@ -18,7 +18,7 @@ impl<'library> Track<'library> {
         }
     }
 
-    pub(crate) fn as_ptr(&self) -> *const ffi::ass_track {
+    pub(crate) fn as_ptr(&mut self) -> *mut ffi::ass_track {
         self.handle.as_ptr()
     }
 


### PR DESCRIPTION
There doesn't seem to be a reason `render_frame` takes ownership of the track. I need this to render whole files using the safe wrapper without needing to reparse sub files every time.